### PR TITLE
feat: add react icons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ yarn.lock
 
 dist/
 vue/
+react/
 preview/index.html
 
 *.log

--- a/generateReact.mjs
+++ b/generateReact.mjs
@@ -1,0 +1,47 @@
+import glob from "glob";
+import camelcase from "camelcase";
+import { readFileSync, writeFileSync } from "fs";
+import { JSDOM } from "jsdom";
+
+const icons = [];
+const pathRegex = /(?<size>\d+)\/(?<name>.*).svg/;
+const capitalize = (str) => str.charAt(0).toUpperCase() + str.slice(1);
+
+const files = glob.sync("./dist/**/*.svg");
+files.forEach((f) => {
+  const svg = readFileSync(f, "utf-8");
+  if (!svg) return;
+  try {
+    const { size, name } = f.match(pathRegex).groups;
+    const dom = new JSDOM(svg).window.document;
+    const el = dom.querySelector("svg");
+    // Might need to wrap the name in quotes as well in the future or just use JSON.stringify on this
+    const attrs = Array.from(el.attributes).map(
+      (attr) => attr.name + `: ` + `'` + attr.value + `'`
+    );
+    const output = [
+      `import React from 'react';`,
+      `export default (attrs) => React.createElement('svg', { ${attrs.join(
+        ", "
+      )}, dangerouslySetInnerHTML: { __html: '${
+        el.innerHTML
+      }' }, ...attrs, });`,
+    ].join("\n");
+    const filename = `${name}-${size}.js`;
+    const path = "./react/" + filename;
+    writeFileSync(path, output, "utf-8");
+    icons.push({ name, size, filename });
+  } catch (err) {
+    console.error(err);
+  }
+});
+
+const indexFile = icons
+  .map(
+    ({ name, size, filename }) =>
+      `export { default as ${capitalize(
+        camelcase("icon-" + name)
+      )}${size} } from './${filename}'`
+  )
+  .join("\n");
+writeFileSync("./react/index.js", indexFile, "utf-8");

--- a/package.json
+++ b/package.json
@@ -5,19 +5,23 @@
   "main": "index.js",
   "files": [
     "dist",
-    "vue"
+    "vue",
+    "react"
   ],
   "exports": {
     ".": "./index.js",
     "./vue": "./vue/index.js",
+    "./react": "./react/index.js",
     "./package.json": "./package.json"
   },
   "scripts": {
     "vue": "rimraf vue && npm run build:vue",
-    "prepublishOnly": "rimraf dist && npm run build && npm run vue",
+    "react": "rimraf react && npm run build:react",
+    "prepublishOnly": "rimraf dist && npm run build && npm run vue && npm run react",
     "import": "node ./scripts/figma-import.js",
     "build": "node ./scripts/build.js",
     "build:vue": "mkdir vue && node ./generateVue.mjs",
+    "build:react": "mkdir react && node ./generateReact.mjs",
     "render": "node preview/render.js",
     "start": "npm run build && node preview/render.js && open ./preview/index.html",
     "version": "npm publish",


### PR DESCRIPTION
Creates a matching icons setup for React. 

React icons components can be imported via `/react`

_Example_
```js
import { IconAlert24, IconAirplane42, IconBag24 } from "@fabric-ds/icons/react";
```

And used as components:

_Example_
```js
<IconAlert24 />
```

