### PR TITLE
Name the React components for improved Fast Refresh

### DIFF
--- a/generateReact.js
+++ b/generateReact.js
@@ -21,7 +21,7 @@ files.forEach((f) => {
     );
     const output = [
       `import React from 'react';`,
-      `export default (attrs) => React.createElement('svg', { ${attrs.join(
+      `export const ${capitalize(camelcase("icon-" + name))}${size} = (attrs) => React.createElement('svg', { ${attrs.join(
         ", "
       )}, dangerouslySetInnerHTML: { __html: '${
         el.innerHTML
@@ -39,9 +39,7 @@ files.forEach((f) => {
 const indexFile = icons
   .map(
     ({ name, size, filename }) =>
-      `export { default as ${capitalize(
-        camelcase("icon-" + name)
-      )}${size} } from './${filename}'`
+      `export * from './${filename}'`
   )
   .join("\n");
 writeFileSync("./react/index.js", indexFile, "utf-8");


### PR DESCRIPTION
Instead of using default export for the components, use named exports:

```
export const IconClock16 = (attrs) => { ... }
```

instead of

```
export default (attrs) => { ... }
```

Then the `index.js` must also be changed to do

```
export * from './clock-16.js'
```

instead of

```
export { * as IconClock16 } from './clock-16.js'
```