### PR TITLE
fix: rework element exports to fix elements part of package

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,35 +18,20 @@ You will need to install both Fabric Elements and Lit Element which is the libra
 npm install lit @fabric-ds/icons
 ```
 
-##### Import all elements
+##### Import elements
 
-Import the elements file, importing will load components. 
-Once imported, all custom elements will be able for use in the page. Element names are prefixed with `f-icon`
+Import the individual element file, importing will load the component. 
+Once imported, run your script through whatever bundling process your app uses (Rollup, Esbuild, etc) 
+after which the component can be used in the page.
 
 ```js
-import from '@fabric-ds/icons/elements';
+import '@fabric-ds/icons/elements/attachment-16';
+import '@fabric-ds/icons/elements/attachment-24';
 ```
 
 ```html
 <f-icon-attachment16></f-icon-attachment16>
 <f-icon-attachment24></f-icon-attachment24>
-<f-icon-attachment32></f-icon-attachment32>
-<f-icon-automatic24></f-icon-automatic24>
-<f-icon-automatic32></f-icon-automatic32>
-etc
-```
-
-##### Import individual elements
-
-Import the individual element file, importing will load the component. 
-Once imported, the component can be used in the page.
-
-```js
-import from '@fabric-ds/icons/elements/attachment-16';
-```
-
-```html
-<f-icon-attachment16></f-icon-attachment16>
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -4,11 +4,58 @@ The icon set for Fabric, imported from the [Figma project](https://www.figma.com
 
 **Note that the icons in the "raw" folder in this repository should never be used directly, as they aren't optimized.**
 
-## Updating the icons
+## Usage
+
+### Elements
+
+#### Using NPM package
+
+##### Install dependencies
+
+You will need to install both Fabric Elements and Lit Element which is the library we use for custom elements
+
+```
+npm install lit @fabric-ds/icons
+```
+
+##### Import all elements
+
+Import the elements file, importing will load components. 
+Once imported, all custom elements will be able for use in the page. Element names are prefixed with `f-icon`
+
+```js
+import from '@fabric-ds/icons/elements';
+```
+
+```html
+<f-icon-attachment16></f-icon-attachment16>
+<f-icon-attachment24></f-icon-attachment24>
+<f-icon-attachment32></f-icon-attachment32>
+<f-icon-automatic24></f-icon-automatic24>
+<f-icon-automatic32></f-icon-automatic32>
+etc
+```
+
+##### Import individual elements
+
+Import the individual element file, importing will load the component. 
+Once imported, the component can be used in the page.
+
+```js
+import from '@fabric-ds/icons/elements/attachment-16';
+```
+
+```html
+<f-icon-attachment16></f-icon-attachment16>
+```
+
+## Development
+
+### Updating the icons
 
 Icons should never be added or edited manually in this repository, as the source of truth is in [Figma](https://www.figma.com/file/pY4zC5fnUv7CPjwSrJV9nT/).
 
-### Figma access token
+#### Figma access token
 
 If you are running the import script for the first time, it will prompt your for a [Figma access token](https://www.figma.com/developers/api#access-tokens). The token is is required to access Figma's API. It can be generated on your Figma account settings page.
 
@@ -42,12 +89,12 @@ npm publish
 git push --follow-tags
 ```
 
-## Troubleshooting
+### Troubleshooting
 
-### Auth
+#### Auth
 
 If the scripts authentication issues, you could try to create a new access token and delete the local file `.FIGMA_TOKEN` before running the script again.
 
-### Figma project structure
+#### Figma project structure
 
 The script is probably not resilient to changes in the structure of the Figma project. Changes there will probably require an update of the import script.

--- a/generateElements.js
+++ b/generateElements.js
@@ -26,7 +26,7 @@ files.forEach((f) => {
         `import { LitElement, html } from 'lit';`,
         `import { unsafeHTML } from 'lit/directives/unsafe-html.js';`,
         `const icon = \`${el.innerHTML}\`;`,
-        `class ${className} extends LitElement {`,
+        `export class ${className} extends LitElement {`,
         `  get attrs() {`,
         `    const attrs = { ${attrs.join(', ')} };`,
         `    Array.from(this.attributes).forEach(({ nodeName, nodeValue }) => attrs[nodeName] = nodeValue);`,
@@ -35,7 +35,7 @@ files.forEach((f) => {
         `  render() { return html\`\${unsafeHTML(\`<svg \${this.attrs}>\${icon}</svg>\`)}\`; }`,
         `}`,
         `if (!customElements.get('f-icon-${name}${size}', ${className})) {`,
-        `  customElements.define('f-icon-${name}${size}', ${className})`,
+        `  customElements.define('f-icon-${name}${size}', ${className});`,
         `}`,
     ].join("\n");
     const filename = `${name}-${size}.js`;
@@ -50,7 +50,7 @@ files.forEach((f) => {
 const indexFile = icons
   .map(
     ({ name, size, filename }) =>
-      `import from './${filename}'`
+      `export * from './${filename}';`
   )
   .join("\n");
 writeFileSync("./elements/index.js", indexFile, "utf-8");

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "./vue": "./vue/index.js",
     "./react": "./react/index.js",
     "./elements": "./elements/index.js",
+    "./elements/*": "./elements/*.js",
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
This is just a first stage fix for the custom elements npm package. The docs explain usage but with this change it is possible to import an individual component or the whole package.

After this fix I want to go back and look at adding Eik builds for the all 3 of the icon sets