### PR TITLE
fix: memory leak when using Lit icons in SSR context

### DIFF
--- a/scripts/output/elements.js
+++ b/scripts/output/elements.js
@@ -12,16 +12,18 @@ getSVGs().forEach(({ svg, name, size, filename, exportName }) => {
   const attrs = Array.from(svg.attrs).map(attr => attr.name + `: ` + `'` + attr.value + `'`)
   const className = exportName
   const output = [
-    `import { LitElement, html } from 'lit';`,
-    `import { unsafeHTML } from 'lit/directives/unsafe-html.js';`,
-    `const icon = \`${svg.html}\`;`,
+    `import { LitElement, html, svg } from 'lit';`,
+    ``,
     `export class ${className} extends LitElement {`,
+    `  static _icon() {`,
+    `    return svg\`${svg.html}\`;`,
+    `  }`,
     `  get attrs() {`,
     `    const attrs = { ${attrs.join(', ')} };`,
     `    Array.from(this.attributes).forEach(({ nodeName, nodeValue }) => attrs[nodeName] = nodeValue);`,
     `    return Object.entries(attrs).map(([k, v]) => \`\${k}="\${v}"\`).join(' ');`,
     `  }`,
-    `  render() { return html\`\${unsafeHTML(\`<svg \${this.attrs}>\${icon}</svg>\`)}\`; }`,
+    `  render() { return html\`<svg \${this.attrs}>\${this.constructor._icon()}</svg>\`; }`,
     `}`,
     `if (!customElements.get('f-icon-${name}${size}', ${className})) {`,
     `  customElements.define('f-icon-${name}${size}', ${className});`,


### PR DESCRIPTION
Example icon this produces:

```js
import { LitElement, html, svg } from 'lit';

export class IconAds16 extends LitElement {
  static _icon() {
    return svg`<title>Ark med bilde og overskrift</title><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M12 4H4v3h8V4ZM4 11h8"></path><path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M2 1h12a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1Z"></path>`;
  }
  get attrs() {
    const attrs = { xmlns: 'http://www.w3.org/2000/svg', width: '16', height: '16', fill: 'none', viewBox: '0 0 16 16' };
    Array.from(this.attributes).forEach(({ nodeName, nodeValue }) => attrs[nodeName] = nodeValue);
    return Object.entries(attrs).map(([k, v]) => `${k}="${v}"`).join(' ');
  }
  render() { return html`<svg ${this.attrs}>${this.constructor._icon()}</svg>`; }
}
if (!customElements.get('f-icon-ads16', IconAds16)) {
  customElements.define('f-icon-ads16', IconAds16);
}
```