### PR TITLE
fix: set attributes on icons

### DIFF
--- a/scripts/output/elements.js
+++ b/scripts/output/elements.js
@@ -9,21 +9,13 @@ const basepath = joinPath(__dirname, '../../elements/')
 mkdirSync(basepath, { recursive: true })
 
 getSVGs().forEach(({ svg, name, size, filename, exportName }) => {
-  const attrs = Array.from(svg.attrs).map(attr => attr.name + `: ` + `'` + attr.value + `'`)
+  const attrs = Array.from(svg.attrs).map(attr => attr.name + `=` + `"` + attr.value + `"`)
   const className = exportName
   const output = [
     `import { LitElement, html, svg } from 'lit';`,
     ``,
     `export class ${className} extends LitElement {`,
-    `  static _icon() {`,
-    `    return svg\`${svg.html}\`;`,
-    `  }`,
-    `  get attrs() {`,
-    `    const attrs = { ${attrs.join(', ')} };`,
-    `    Array.from(this.attributes).forEach(({ nodeName, nodeValue }) => attrs[nodeName] = nodeValue);`,
-    `    return Object.entries(attrs).map(([k, v]) => \`\${k}="\${v}"\`).join(' ');`,
-    `  }`,
-    `  render() { return html\`<svg \${this.attrs}>\${this.constructor._icon()}</svg>\`; }`,
+    `  render() { return html\`<svg ${attrs.join(' ')}>${svg.html}</svg>\`; }`,
     `}`,
     `if (!customElements.get('f-icon-${name}${size}', ${className})) {`,
     `  customElements.define('f-icon-${name}${size}', ${className});`,


### PR DESCRIPTION
Fixes an issue where attributes weren't being included on SVG element. This was because you can't spread or dynamically define attributes on a Lit element in the same way you can in React and Vue. 

Additionally, using the svg template literal was resulting in nested svgs elements which kinda seems like a bug in Lit. In any case, its fine to just define the entire SVG in a single html template literal so this PR does that.